### PR TITLE
Publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish amisrsynthdata to PyPI
 
 on:
   pull_request:
-    branches: ['main','develop']
+    branches: ['auto_publish']
   release:
     types: [published]
   # push
@@ -17,7 +17,7 @@ jobs:
     environment:
       #name: pypi
       name: testpypi
-      url: https://pypi.org/p/amisrsynthdata
+      url: https://test.pypi.org/project/amisrsynthdata
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,13 @@ on:
     branches: ['auto_publish']
   release:
     types: [published]
-  # push
+  push:
+    branches: ['auto_publish']
 
 jobs:
-  pypi-publish:
-    name: Upload release to PyPI
+  build:
+    name: Build release
     runs-on: ubuntu-latest
-    environment:
-      #name: pypi
-      name: testpypi
-      url: https://test.pypi.org/project/amisrsynthdata
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     # retrieve your distributions here
     - name: Checkout latest push
@@ -32,6 +27,28 @@ jobs:
       run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      #name: pypi
+      name: testpypi
+      url: https://test.pypi.org/project/amisrsynthdata
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      #    # retrieve your distributions here
+      #    - name: Checkout latest push
+      #      uses: actions/checkout@v3
+      #    - name: Set up Python
+      #      uses: actions/setup-python@v4
+      #      with:
+      #        python-version: '3.10'
+      #    - name: Install pypa/build
+      #      run: python -m pip install build --user
+      #    - name: Build a binary wheel and a source tarball
+      #      run: python -m build --sdist --wheel --outdir dist/
 
       #- name: Publish package distributions to PyPI
       #  uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,40 @@ on:
     branches: ['auto_publish']
 
 jobs:
-  build:
-    name: Build release
+  pypi-publish:
+    name: Upload release to PyPI
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/amisrsynthdata
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    # retrieve your distributions here
+    - name: Checkout latest push
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install pypa/build
+      run: python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python -m build --sdist --wheel --outdir dist/
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  test-pypi-publish:
+    name: Upload release to TestPyPI
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      #name: pypi
+      name: testpypi
+      url: https://test.pypi.org/project/amisrsynthdata
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     # retrieve your distributions here
     - name: Checkout latest push
@@ -28,31 +59,8 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/
 
-  pypi-publish:
-    name: Upload release to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      #name: pypi
-      name: testpypi
-      url: https://test.pypi.org/project/amisrsynthdata
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    steps:
-      #    # retrieve your distributions here
-      #    - name: Checkout latest push
-      #      uses: actions/checkout@v3
-      #    - name: Set up Python
-      #      uses: actions/setup-python@v4
-      #      with:
-      #        python-version: '3.10'
-      #    - name: Install pypa/build
-      #      run: python -m pip install build --user
-      #    - name: Build a binary wheel and a source tarball
-      #      run: python -m build --sdist --wheel --outdir dist/
-
-      #- name: Publish package distributions to PyPI
-      #  uses: pypa/gh-action-pypi-publish@release/v1
+    #- name: Publish package distributions to PyPI
+    #  uses: pypa/gh-action-pypi-publish@release/v1
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,8 @@ jobs:
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        skip_existing: true
+        verbose: true
         repository-url: https://test.pypi.org/legacy/
 
           #jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
+    needs: build
     runs-on: ubuntu-latest
     environment:
       #name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,9 @@ name: Publish amisrsynthdata to PyPI
 
 on:
   pull_request:
-    branches: ['auto_publish']
+    branches: ['main','develop']
   release:
     types: [published]
-  push:
-    branches: ['auto_publish']
 
 jobs:
   pypi-publish:
@@ -38,10 +36,9 @@ jobs:
 
   test-pypi-publish:
     name: Upload release to TestPyPI
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     environment:
-      #name: pypi
       name: testpypi
       url: https://test.pypi.org/project/amisrsynthdata
     permissions:
@@ -58,9 +55,6 @@ jobs:
       run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/
-
-    #- name: Publish package distributions to PyPI
-    #  uses: pypa/gh-action-pypi-publish@release/v1
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -68,34 +62,4 @@ jobs:
         verbose: true
         repository-url: https://test.pypi.org/legacy/
 
-          #jobs:
-          #  build-n-publish:
-          #    name: Build and publish distribution to PyPI
-          #    runs-on: ubuntu-latest
-          #
-          #    steps:
-          #      - name: Checkout latest push
-          #        uses: actions/checkout@v3
-          #      - name: Set up Python
-          #        uses: actions/setup-python@v4
-          #        with:
-          #          python-version: '3.10'
-          #      - name: Install pypa/build
-          #        run: python -m pip install build --user
-          #      - name: Build a binary wheel and a source tarball
-          #        run: python -m build --sdist --wheel --outdir dist/
-          #      - name: Publish distribution to Test PyPI
-          #        if: github.event_name == 'pull_request'
-          #        uses: pypa/gh-action-pypi-publish@release/v1
-          #        with:
-          #          skip_existing: true
-          #          verbose: true
-          #          # password: ${{ secrets.PYPI_API_TOKEN }}
-          #          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          #          repository_url: https://test.pypi.org/legacy/
-          #
-          #      - name: Publish distribution to PyPI
-          #        if: github.event_name == 'release'
-          #        uses: pypa/gh-action-pypi-publish@release/v1
-          #        with:
-          #          password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ This package installs the command line tool `amisrsynthdata`, which is used alon
 
   $ amisrsynthdata config.yaml
 
-The :ref:`Configuration File` sections contains information about the contents of these configuration files and how to construct one.
+The `Configuration File` sections contains information about the contents of these configuration files and how to construct one.
 
 Limitations
 -----------
@@ -41,5 +41,5 @@ The following are NOT currently included in the amisrsynthdata module:
 Contributing
 ------------
 
-Contributions to this package are welcome and encouraged, particularly to expand the currently set of specified ionospheres.  Create a pull request to submit contributions, or open an issue if you would like to request new features or report a bug.  Specific instructions on how to add a new state function to describe the ionosphere are available in :ref:`New State Functions`.
+Contributions to this package are welcome and encouraged, particularly to expand the currently set of specified ionospheres.  Create a pull request to submit contributions, or open an issue if you would like to request new features or report a bug.  Specific instructions on how to add a new state function to describe the ionosphere are available in `New State Functions`.
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ This package installs the command line tool `amisrsynthdata`, which is used alon
 
   $ amisrsynthdata config.yaml
 
-The `Configuration File` sections contains information about the contents of these configuration files and how to construct one.
+Refer to the `configuration file docs <https://amisrsynthdata.readthedocs.io/en/latest/configfile.html#>`_ for information about the contents of these configuration files and how to construct one.
 
 Limitations
 -----------
@@ -37,6 +37,11 @@ The following are NOT currently included in the amisrsynthdata module:
 1. Any kind of proper treatment or simulation of ISR theory - The module effectively assumes the radar measures plasma parameters perfectly at a particular location, although empirical errors can be added.
 2. Integration over a time period or smearing along the length of pulses, as well as pulse coding.
 3. Madrigal data format - Currently files are only generated in the SRI data format.
+
+Documentation
+-------------
+
+Full documentation for amisrsynthdata is available on `ReadTheDocs <https://amisrsynthdata.readthedocs.io/en/latest/index.html>`_.
 
 Contributing
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name="L. Lamarche", email="leslie.lamarche@sri.com" },
 ]
 description = "Tool for generating synthetic AMISR data files."
-readme = "README.rst"
+#readme = "README.rst"
 license = { file = "LICENSE" }
 keywords = ["AMISR", "synthetic", "data"]
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amisrsynthdata"
-version = "0.0.1"
+version = "0.0.3"
 authors = [
   { name="L. Lamarche", email="leslie.lamarche@sri.com" },
 ]
 description = "Tool for generating synthetic AMISR data files."
-#readme = "README.rst"
+readme = "README.rst"
 license = { file = "LICENSE" }
 keywords = ["AMISR", "synthetic", "data"]
 requires-python = ">=3.7"


### PR DESCRIPTION
This adds a github workflow to automatically publish releases to PyPI.  Additionally, PRs to main will automatically be published to Test PyPI.